### PR TITLE
"After=multi-user.target" in unit file causes ordering cycle

### DIFF
--- a/activate-tracer-service.sh
+++ b/activate-tracer-service.sh
@@ -22,7 +22,6 @@ echo "--- add service details"
 echo "[Unit]" >> $bpf_trace_systemd_path
 echo "Description=ImdsPacketAnalyzer IMDS detection tooling from AWS" >> $bpf_trace_systemd_path
 echo "Before=network-online.target" >> $bpf_trace_systemd_path
-echo "After=multi-user.target" >> $bpf_trace_systemd_path
 echo "" >> $bpf_trace_systemd_path
 
 echo "[Service]" >> $bpf_trace_systemd_path


### PR DESCRIPTION
If system runs in multi-user level(runlevel 3), user cannot login to system because of ordering cycle. So remove it from unit file.

$ systemd-analyze verify default.target
multi-user.target: Found ordering cycle on chronyd.service/start multi-user.target: Found dependency on chrony-config.service/start multi-user.target: Found dependency on network-online.target/start multi-user.target: Found dependency on imds_tracer_tool.service/start multi-user.target: Found dependency on multi-user.target/start multi-user.target: Job chronyd.service/start deleted to break ordering cycle starting with multi-user.target/start

*Issue #, if available:*

Cannot login to system(default multi-user as runlevel 3) with the service enabled.
Below is the error in response.
"System is booting up. Unprivileged users are not permitted to log in yet. Please come back later. For technical details, see pam_nologin(8)."

*Description of changes:*
Remove the "After=multi-user.target" from unit file because it is not must required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
