### PR TITLE
correct default logging directory defined in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Example of a IMDSv2 log entry:
 The logging configuration can be adjusted by editing the **logging.conf** file.
 
 By default:
-- Logs will be saved to the `/var/log/` folder in a file called `imds-trace.log`
+- Logs will be saved to the `/var/log/imds/` folder in a file called `imds-trace.log`
 - Log files will be appended (if the analyzer is stopped and then run again on multiple occasions)
 - Each log file will reach a maximum size of 1 megabyte before rollover occurs
 - When a log file reaches 1mb in size it will rollover to a new log file **i.e) imds-trace.log.1 or imds-trace.log.2** 
@@ -295,7 +295,7 @@ By default:
 
 ### Analyzing log files
 **Assuming default logging setup:** 
-- Running the command `cat /var/log/imds-trace.* | grep WARNING` will output all IMDSv1 calls to the terminal. 
+- Running the command `cat /var/log/imds/imds-trace.* | grep WARNING` will output all IMDSv1 calls to the terminal. 
 - Note that this grep will only identify the call, sometimes the calls leading up to the V1 call can provide additional context.   
 
 # Running the tool as a service


### PR DESCRIPTION
the code https://github.com/aws/aws-imds-packet-analyzer/blob/main/src/imds_snoop.py lists `/var/log/imds/` as the default folder 

```python
  # initialize logger
  if os.path.exists(LOGGING_CONFIG_FILE):
    print("Using config file as one was provided.")
    fileConfig(LOGGING_CONFIG_FILE)
    logger = logging.getLogger()
  else:  # No config file is preferred as we want to ensure the locked down folder is used.
    print("Logging to /var/log/imds/imds-trace.log")
    logger = logging.getLogger()
    c_handler = RotatingFileHandler('/var/log/imds/imds-trace.log', 'a', 1048576, 5, 'UTF-8')
    c_handler.setLevel(logging.INFO)
    c_format = logging.Formatter('[%(asctime)s] [%(levelname)s] %(message)s')
    c_handler.setFormatter(c_format)
    logger.addHandler(c_handler)
```
also verified after building and running as a service 

```bash
root@pd-imds-v1:~# systemctl status -l imds_tracer_tool.service
● imds_tracer_tool.service - ImdsPacketAnalyzer IMDS detection tooling from AWS
     Loaded: loaded (/etc/systemd/system/imds_tracer_tool.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2023-11-14 09:48:26 UTC; 14min ago
   Main PID: 4186 (python3)
      Tasks: 1 (limit: 2329)
     Memory: 112.4M
        CPU: 3.763s
     CGroup: /system.slice/imds_tracer_tool.service
             └─4186 /usr/bin/python3 /home/ubuntu/aws-imds-packet-analyzer/src/imds_snoop.py

Nov 14 09:48:26 pd-imds-v1 systemd[1]: Started ImdsPacketAnalyzer IMDS detection tooling from AWS.
root@pd-imds-v1:~# ls -l /var/log/imds/
total 0
-rw-r--r-- 1 root root 0 Nov 14 09:48 imds-trace.log
root@pd-imds-v1:~# 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
