### PR TITLE
align with kernel change in renaming iov_iter->iov to iov_iter->__iov

### DIFF
--- a/src/bpf.c
+++ b/src/bpf.c
@@ -44,8 +44,18 @@ int trace_sock_sendmsg(struct pt_regs *ctx)
         if (!data) // this should never happen, just making the verifier happy
           return 0;
 
+        #if defined(iter_iov) || defined (iter_iov_len)
+        const struct iovec * iov = msghdr->msg_iter.__iov;
+        #else
         const struct iovec * iov = msghdr->msg_iter.iov;
-        void *iovbase = iov->iov_base;
+        #endif
+        const void *iovbase;
+        if (*(char *)iov->iov_base == '\0'){
+          iovbase = iov;
+        }
+        else{
+          iovbase = iov->iov_base;
+        }
         const size_t iovlen = iov->iov_len > MAX_PKT ? MAX_PKT : iov->iov_len;
         
         if (!iovlen) {


### PR DESCRIPTION
*Issue #, if available:*
In some newer kernels or relative patches picked, it cannot compile successfully.
# python imds_snoop.py 
Logging to /var/log/imds/imds-trace.log
/virtual/main.c:47:53: error: no member named 'iov' in 'struct iov_iter'
   47 |         const struct iovec * iov = msghdr->msg_iter.iov;
      |                                    ~~~~~~~~~~~~~~~~ ^
1 error generated.
Traceback (most recent call last):
  File "/home/ec2-user/aws-imds-packet-analyzer/src/imds_snoop.py", line 195, in <module>
    b = BPF('bpf.c')
  File "/usr/lib/python3.9/site-packages/bcc/__init__.py", line 479, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
Exception: Failed to compile BPF module b'bpf.c'

*Description of changes:*
Access new iov_iter->__iov when new function iter_iov or iter_iov_len defined.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
