### PR TITLE
Added Fedora as it works now after a9a4b25

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The ImdsPacketAnalyzer leverages the [BCC (BPF Compiler Collection)](https://git
 	- [Debian 11](#debian-11)
 	- [Debian 10](#debian-10)
 	- [Ubuntu 20 / 22](#ubuntu-20--22)
-	- [RHEL 8 / 9](#rhel-8--9)
+	- [RHEL 8 / 9 / Fedora](#rhel-8--9--fedora)
 	- [SLES 15](#sles-15)
 	- [Windows](#windows)
 - [Usage](#usage-)
@@ -24,7 +24,7 @@ The ImdsPacketAnalyzer leverages the [BCC (BPF Compiler Collection)](https://git
 	- [Debian 11](#debian-11-1)
 	- [Debian 10](#debian-10-1)
 	- [Ubuntu 20 / 22](#ubuntu-20--22-1)
-	- [RHEL 8 / 9](#rhel-8--9-1)
+	- [RHEL 8 / 9 / Fedora](#rhel-8--9--fedora-1)
 	- [SLES 15](#sles-15-1)
 	- [Windows](#windows-1)
 - [Logging](#logging)
@@ -127,7 +127,7 @@ sudo apt-get install linux-headers-$(uname -r)
 ```
 ---
 
-## RHEL 8 / 9
+## RHEL 8 / 9 / Fedora
 
 ```
 sudo yum -y install bcc-tools libbpf
@@ -232,7 +232,7 @@ sudo LD_PRELOAD=/home/ubuntu/bcc/build/src/cc/libbcc.so.0 PYTHONPATH=/home/ubunt
 ```
 ---
 
-## RHEL 8 / 9
+## RHEL 8 / 9 / Fedora
 ```
 sudo python3 src/imds_snoop.py
 ```

--- a/deactivate-tracer-service.sh
+++ b/deactivate-tracer-service.sh
@@ -24,4 +24,4 @@ echo ""
 
 echo "[INFO] Associated log files can be found in the /var/log/ directory"
 echo "Run the following command to delete all log files: "
-echo "sudo rm /var/log/imds-trace.*"
+echo "sudo rm /var/log/imds/imds-trace.*"

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -123,6 +123,9 @@ elif grep -q 'ID=ubuntu' /etc/os-release  &&  grep -q 'VERSION_ID="20.04"' /etc/
 elif grep -q 'ID="rhel"' /etc/os-release; then
     #RHEL 8 and 9
     yum -y install bcc-tools libbpf
+elif grep -q 'ID=fedora' /etc/os-release; then
+    #Fedora
+    yum -y install bcc-tools libbpf
 elif grep -q 'ID="sles"' /etc/os-release  && grep -q 'VERSION_ID="15.[0-4]"' /etc/os-release ; then
     #SLES 15
     zypper ref


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added Fedora to support list as it works as RHEL-8 and 9.
`[WARNING] IMDSv1(!) (pid:3429:curl argv:) called by -> (pid:3353:bash argv:bash) -> (pid:3352:su argv:su) -> (pid:3351:sudo argv:sudo su) Req details: GET /latest/meta-data/ami-id HTTP/1.1, Host: 169.254.169.254, User-Agent: curl/8.2.1, Accept: */*, 
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
