### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-secret-scan.yml
+++ b/.github/workflows/pr-secret-scan.yml
@@ -1,4 +1,6 @@
 name: Leaked Secrets Scan
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-imds-packet-analyzer/security/code-scanning/2](https://github.com/aws/aws-imds-packet-analyzer/security/code-scanning/2)

To fix this problem, explicitly set the `permissions` key in the workflow, ideally at the top/root of the file (root-level permissions) so it applies to all jobs. The least privilege required for this workflow is to enable reading (but not writing) repository contents, which is done via `permissions: contents: read`. No other permission scopes appear needed for these steps. You should add the following lines directly underneath the workflow's `name:` declaration and before `on:` at the top of the `.github/workflows/pr-secret-scan.yml` file:
```yaml
permissions:
  contents: read
```
This ensures all jobs in the workflow receive a token limited to only reading repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
