### PR TITLE
fix(bpf.c): fix the recent change that prevents the tool from running

### DIFF
--- a/src/bpf.c
+++ b/src/bpf.c
@@ -9,10 +9,10 @@
 #include <linux/sched.h>
 
 // Forward declarations to fix kernel 6.12+ compatibility
-struct bpf_wq {};
-struct bpf_rb_root {};
-struct bpf_rb_node {};
-struct bpf_refcount {};
+struct bpf_wq;
+struct bpf_rb_root;
+struct bpf_rb_node;
+struct bpf_refcount;
 
 #include <net/sock.h>
 


### PR DESCRIPTION
…src/bpf.c

The recent change in src/bpf.c has compilation error that has broken the package from running. This patch converts those struct definitions into actual declarations

*Issue #, if available:*

*Description of changes:* fixes the forward declared structs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
